### PR TITLE
Allow setting output by period instead of frequency

### DIFF
--- a/RFout1MHzV1_06/RFout1MHzV1_06.ino
+++ b/RFout1MHzV1_06/RFout1MHzV1_06.ino
@@ -361,6 +361,10 @@ bool strapped_for_passthrough() {
   return result;
 }
 
+struct eeprom_data {
+    uint32_t freq;
+};
+
 
 unsigned long GetEEPROM_CRC(void) {
 
@@ -373,7 +377,7 @@ unsigned long GetEEPROM_CRC(void) {
 
   unsigned long crc = ~0L;
 
-  for (int index = 0 ; index < sizeof(freq) ; ++index) {
+  for (int index = 0 ; index < sizeof(eeprom_data) ; ++index) {
     crc = crc_table[(crc ^ EEPROM[index]) & 0x0f] ^ (crc >> 4);
     crc = crc_table[(crc ^ (EEPROM[index] >> 4)) & 0x0f] ^ (crc >> 4);
     crc = ~crc;
@@ -384,9 +388,10 @@ unsigned long GetEEPROM_CRC(void) {
 void SaveToEPROM ()
 {
 unsigned long CRCFromEEPROM;
-  EEPROM.put(0, freq);                     //Save the Freqency to EEPROM at address0
+  eeprom_data e = {freq};
+  EEPROM.put(0, e);                     //Save the Freqency to EEPROM at address0
   CRCFromEEPROM=GetEEPROM_CRC ();          //Calculate CRC on the saved data
-  EEPROM.put(sizeof(freq), CRCFromEEPROM); //Save the CRC after the data
+  EEPROM.put(sizeof(eeprom_data), CRCFromEEPROM); //Save the CRC after the data
 }
 
 
@@ -394,9 +399,11 @@ bool LoadFromEPROM (void)
 {
 unsigned long CRCFromEEPROM,CalculatedCRC;
 
-  EEPROM.get(0, freq);                           //Load the Frequency from EEPROM address 0
-  EEPROM.get(sizeof(freq), CRCFromEEPROM);       //Load the CRC value that is stored in EEPROM
+  eeprom_data e;
+  EEPROM.get(0, &e);                           //Load the Frequency from EEPROM address 0
+  EEPROM.get(sizeof(eeprom_data), CRCFromEEPROM);       //Load the CRC value that is stored in EEPROM
   CalculatedCRC=GetEEPROM_CRC();                 //Calculate the CRC of the Frequency
+  freq = e.freq;
   return (CRCFromEEPROM==CalculatedCRC);         //If  Stored and Calculated CRC are the same then return true
 }
 

--- a/RFout1MHzV1_06/RFout1MHzV1_06.ino
+++ b/RFout1MHzV1_06/RFout1MHzV1_06.ino
@@ -122,26 +122,27 @@ void setup()
 // Handle serial commands
 void handle_serial() {
   int c = Serial.read();
-  if(c == 'P' || c=='p') {
-    Serial.println(F("Entering passthrough mode -- reset microcontroller to return to normal mode\n"));
-    passthrough = true;
-  }
-   else if(c == 'S' || c == 's') {
-    SaveToEPROM ();
-    Serial.println(F("Time pulse setting was saved"));
-  }
-  else if(c == 'H' || c == 'h') {
-    HelpText ();  
-  }
-  else if(c == 'F' || c == 'f') {
-    Serial.print(F("Frequency?"));
-    cmdstate = 1; freq = period = 0;
-  }
-  else if(c == 'T' || c == 't') {
-    Serial.print(F("Period?"));
-    cmdstate = 2; freq = period = 0;
-  }
-  else if(cmdstate == 1) {
+  if(cmdstate == 0) {
+    if(c == 'P' || c=='p') {
+      Serial.println(F("Entering passthrough mode -- reset microcontroller to return to normal mode\n"));
+      passthrough = true;
+    }
+     else if(c == 'S' || c == 's') {
+      SaveToEPROM ();
+      Serial.println(F("Time pulse setting was saved"));
+    }
+    else if(c == 'H' || c == 'h') {
+      HelpText ();
+    }
+    else if(c == 'F' || c == 'f') {
+      Serial.print(F("Frequency?"));
+      cmdstate = 1; freq = period = 0;
+    }
+    else if(c == 'T' || c == 't') {
+      Serial.print(F("Period?"));
+      cmdstate = 2; freq = period = 0;
+    }
+  } else if(cmdstate == 1) {
     if(c >= '0' && c <= '9') {
       Serial.write(c);
       freq = freq * 10 + c - '0';
@@ -176,8 +177,6 @@ void handle_serial() {
       period *= 1000000lu;
     } else if (c == 'M' || c == 'm') {
       Serial.write(c);
-      period *= 1000lu;
-    } else if (c == 'U' || c == 'u') {
       period *= 1000lu;
     } else if (c == '\n' || c == '\r') {
       Serial.println(F(""));

--- a/RFout1MHzV1_06/RFout1MHzV1_06.ino
+++ b/RFout1MHzV1_06/RFout1MHzV1_06.ino
@@ -256,6 +256,7 @@ uint8_t setOutputFreq[] = {
 0x00, 0x00, 0xEF, 0x00, 0x00, 0x00, 0x20, 0x1B
 };
 
+// Note: these offsets are from the beginning of the packet header, not the payload; as such, they differ by 6 from the payload byte offsets in the PDF
 #define OFFSET_FREQUENCY_LOCKED (18)
 #define OFFSET_FLAGS (34)
 #define OFFSET_CKSUM (38)


### PR DESCRIPTION
The U-Blox GPS module can create a time pulse selected by frequency in Hz or by period in microseconds (µs or us).  Both must be whole numbers, so it is not possible to select (for example) a square wave of 100/3Hz ~= 33.3Hz.  However, the period of this square wave is 30000us, and can be requested as such.

This pull request adds a new "T" (time) command to the serial protocol.  You can enter e.g., "T30000" or "T30m" for 30000us = 30ms.

The maximum time that can be requested is 2^31-1us ~= 465microHz.

The last command, whether by T or by P, is saved with S and restored at power-on.

A behavioral change: It used to be possible to say "P10Ms" all on one line to set and save the frequency, but this is not allowed anymore since "T1s" is used to set 1 second.

I have only tested values down to 10us (100kHz) due to the limitations of my little frequency counter.  I'll update this pull request soon with info about how slower waveforms look on my scope.

Arduino reports that the firmware is 42% full after these changes.